### PR TITLE
disabled "next" buttons if not valid input

### DIFF
--- a/sender-client/src/app/pages/frontpage/frontpage.component.html
+++ b/sender-client/src/app/pages/frontpage/frontpage.component.html
@@ -16,7 +16,7 @@
 <div class="row">
   <div class="col-md-12" >
           <a [routerLink]="'/summary'">
-              <button id="nextButton" type="Next" class="btn btn-info  btn-round" style="float: right;">
+              <button [disabled]="!isValid || !isUploaded " id="nextButton" type="Next" class="btn btn-info  btn-round" style="float: right;">
                   <span >Nästa</span>
               </button>
           </a>

--- a/sender-client/src/app/pages/frontpage/frontpage.component.ts
+++ b/sender-client/src/app/pages/frontpage/frontpage.component.ts
@@ -6,8 +6,8 @@
 
 /* Imports */
 import { Component, OnInit } from '@angular/core';
-
 import { Routes } from '@angular/router';
+import { UploadService } from 'app/shared/upload.service';
 
 
 @Component({
@@ -24,8 +24,9 @@ export class FrontpageComponent implements OnInit {
   // is image uploaded locally
   public isUploaded: boolean; 
 
-
-
+  constructor(){
+  }
+  
   /**
     * sets boolean isValid to same value as in child component card-form.component
     */
@@ -37,16 +38,11 @@ export class FrontpageComponent implements OnInit {
     * sets boolean isUploaded to same value as in child component card-image.component
     */
   public setUploadBoolean(isUploaded: boolean): void {
-    if (this.isValid) {
-      this.isUploaded = isUploaded;
-    }
+    this.isUploaded = isUploaded;
   }
 
- 
-    ngOnInit() {
-      this.isValid=false;
-      this.isUploaded=false;
-
-     };
-
+  ngOnInit() {
+    this.isValid=false;
+    this.isUploaded=false;
+  };
 }

--- a/sender-client/src/app/pages/summary/summary.component.html
+++ b/sender-client/src/app/pages/summary/summary.component.html
@@ -10,12 +10,8 @@
 </div>
 
 <div *ngIf="!displayForm"><app-card-default (displayForm)="setDisplayForm($event)"></app-card-default></div>
-<div *ngIf="displayForm"><app-card-form ></app-card-form></div>
-<app-card-image [isValid]="!isValid" Message="Lägg till fler bilder" (imageUploaded)="setUploadBoolean($event)"></app-card-image>
-
-
-
- 
+<div *ngIf="displayForm"><app-card-form (onSaveForm)="setValidity($event)"></app-card-form></div>
+<app-card-image [isValid]="isValid" Message="Lägg till fler bilder" (imageUploaded)="setUploadBoolean($event)"></app-card-image>
 
 <div class="row">
 
@@ -25,7 +21,7 @@
         <button id="cancelButton" type="previous" class="btn btn-info  btn-round" style="float: left;" mat-raised-button (click)="openDialog()" >Avbryt</button>
 
         <a [routerLink]="'/confirmation'">
-            <button id="skickaButton" type="Skicka Ärende" class="btn btn-info  btn-round" style="float: right;" (click)="startUpload()">
+            <button [disabled]="!isUploaded || !isValid" id="skickaButton" type="Skicka Ärende" class="btn btn-info  btn-round" style="float: right;" (click)="startUpload()">
                 <span>Skicka Ärende</span>
             </button>
         </a>

--- a/sender-client/src/app/pages/summary/summary.component.ts
+++ b/sender-client/src/app/pages/summary/summary.component.ts
@@ -26,8 +26,6 @@ import { CaseDataService } from 'app/shared/case-data.service';
 })
 export class SummaryComponent implements OnInit {
 
-
-
 /**
    * @param uploadService 
    * @param dialog 
@@ -61,25 +59,18 @@ export class SummaryComponent implements OnInit {
    * sets boolean isValid to same value as in child component card-form.component
    */
  public setValidity(isValid: boolean): void {
- 
   this.isValid = isValid;
- 
 }
 
 public setDisplayForm(displayForm: boolean): void {
- 
  this.displayForm = displayForm;
-
 }
 
  /**
    * sets boolean isUploaded to same value as in child component card-image.component
    */
  public setUploadBoolean(isUploaded: boolean): void {
- 
-  if (this.isValid) {
      this.isUploaded = isUploaded;
-   }
  }
 
  /**
@@ -105,12 +96,15 @@ public setDisplayForm(displayForm: boolean): void {
     });
   }
 
-
-   ngOnInit() {
-     this.isValid=false;
-     this.isUploaded=false;
+  /**
+   * Set isValid and isUploaded to true since it
+   * must be for the user to acess this page
+   */
+  ngOnInit() {
+     this.isValid=true;
+     this.isUploaded= true;
      this.displayForm= false;
-    };
+  };
 
 
 }

--- a/sender-client/src/app/shared/cards/card-image/card-image.component.html
+++ b/sender-client/src/app/shared/cards/card-image/card-image.component.html
@@ -28,7 +28,7 @@ This is an sample page to illustrate, each new "page" will have a new folder for
                     <button id="uploadPicture" type="submit" class="btn btn-info  btn-round" [disabled]="!isValid" (click)="openFileSelect()" >
                         <i class="nc-icon circle-icon nc-ruler-pencil"></i>
 
-                        <input id="inputUploadPicture"style="display: none" type="file" accept=".jpeg,.png,.tif" (change)="saveImageToCase($event)" class="upload-input" #selectFile>
+                        <input id="inputUploadPicture"style="display: none" type="file" accept=".jpg, .jpeg,.png,.tif" (change)="saveImageToCase($event)" class="upload-input" #selectFile>
                         <span [hidden]="!imagesAvailable">{{Message}}</span>
                         <span [hidden]="imagesAvailable">{{Message}} </span>
 

--- a/sender-client/src/app/shared/cards/card-image/card-image.component.ts
+++ b/sender-client/src/app/shared/cards/card-image/card-image.component.ts
@@ -57,8 +57,8 @@ saveImageToCase(event){
     return;
   }
 
-  // 209715.2 = 0.2mb
-  if(event.target.files[0].size < 209715.2) {
+  // 102400 = 0.1 MB
+  if(event.target.files[0].size < 102400) {
     alert("The size of the images must exceed 0.2 megabytes.");
     return;
   }
@@ -74,7 +74,8 @@ saveImageToCase(event){
   this.dataService.getCase().images.push(this.image);
 
   // send to parent if image is uploaded
-  this.imageUploaded.emit(this.imagesAvailable)
+  this.imagesAvailable = true;
+  this.imageUploaded.emit(this.imagesAvailable);
 
   this.addImage();
 }
@@ -89,6 +90,10 @@ removeImage(index: number){
   this._album.splice(index, 1);
   this.loadImages();
   this.imageCounter--;
+  if ( this.imageCounter === -1){
+    this.imagesAvailable = false;
+    this.imageUploaded.emit(this.imagesAvailable);
+  }
 }
 
 /**

--- a/sender-client/src/app/shared/case-data.service.ts
+++ b/sender-client/src/app/shared/case-data.service.ts
@@ -44,9 +44,10 @@ export class CaseDataService {
     this.caseData.user.name = "";
     this.caseData.user.email = "";
     this.caseData.user.phone = "";
-  
+
     //TODO CLEAR IMAGE ARRAY
   }
+
 }
 
 


### PR DESCRIPTION
1. Disabled the "next" buttons on frontpage and summary page, if the form and image-card isn´t valid

Extra fixes!!!!!! :
2. Added "jpg" as a valid filetype (only "jpeg" worked before) in image-card
3. Change the minumun filesize from 0,2 mg to 0,1 mg, since the SRS says 0,1, in image-card